### PR TITLE
Changed addAttachments to accept multiple files

### DIFF
--- a/lib/src/main/java/com/grio/lib/features/editor/EditorViewModel.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/EditorViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.grio.lib.core.platform.BaseViewModel
 import com.grio.lib.features.editor.cases.AddAttachment
 import com.grio.lib.features.editor.cases.CreateIssue
-import okhttp3.MediaType
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import java.io.File
 import javax.inject.Inject
 
@@ -46,12 +44,12 @@ class EditorViewModel
             Log.i("BugSnap", "Successfully create issue.")
 
             if (file.isFile) {
-                files.add(addAttachment.prepareFilePart(file, "image/*"))
+                files.add(AddAttachment.prepareFilePart(file, "image/*"))
             }
 
 
             if (logString.isNotEmpty()) {
-                files.add(addAttachment.prepareFilePart("logcat.log", logString, "text/plain"))
+                files.add(AddAttachment.prepareFilePart("logcat.log", logString, "text/plain"))
             }
 
             addAttachment(AddAttachment.Params(it.id, files)) { it.either({

--- a/lib/src/main/java/com/grio/lib/features/editor/JiraApi.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/JiraApi.kt
@@ -18,13 +18,13 @@ internal interface JiraApi {
     fun createIssue(@Body req: CreateIssueRequest) : Call<CreateIssueResponse>
 
     /**
-     * Add an attachment to an issue.
+     * Add one or more attachments to an issue.
      */
     @Multipart
     @Headers("X-Atlassian-Token: no-check")
     @POST("rest/api/2/issue/{issueId}/attachments")
     fun addAttachment(@Path("issueId") issueId: String,
-                      @Part filePart: MultipartBody.Part): Call<ResponseBody>
+                      @Part filePart: List<MultipartBody.Part>): Call<ResponseBody>
 
 
     /**

--- a/lib/src/main/java/com/grio/lib/features/editor/JiraRepository.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/JiraRepository.kt
@@ -17,7 +17,7 @@ interface JiraRepository {
 
     fun createIssue(summary: String, description: String): Either<Failure, CreateIssueResponse>
     fun getCreationMeta(): Either<Failure, CreationMeta>
-    fun addAttachment(issueId: String, file: MultipartBody.Part) : Either<Failure, ResponseBody>
+    fun addAttachment(issueId: String, files: List<MultipartBody.Part>) : Either<Failure, ResponseBody>
 
     /**
      * A [JiraRepository] implementation for network calls.
@@ -27,9 +27,9 @@ interface JiraRepository {
                         private val service: JiraService
     ) : JiraRepository {
 
-        override fun addAttachment(issueId: String, file: MultipartBody.Part): Either<Failure, ResponseBody> {
+        override fun addAttachment(issueId: String, files: List<MultipartBody.Part>): Either<Failure, ResponseBody> {
             return when (networkHandler.isConnected) {
-                true -> request(service.addAttachment(issueId, file), { it }, ResponseBody.create(MediaType.parse(""), ""))
+                true -> request(service.addAttachment(issueId, files), { it }, ResponseBody.create(MediaType.parse(""), ""))
                 false, null -> Either.Left(Failure.NetworkConnection())
             }
         }

--- a/lib/src/main/java/com/grio/lib/features/editor/JiraService.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/JiraService.kt
@@ -22,6 +22,6 @@ class JiraService
 
     override fun getCreationMeta() = jiraApi.getCreationMeta()
 
-    override fun addAttachment(issueId: String, filePart: MultipartBody.Part) = jiraApi.addAttachment(issueId, filePart)
+    override fun addAttachment(issueId: String, fileParts: List<MultipartBody.Part>) = jiraApi.addAttachment(issueId, fileParts)
 
 }

--- a/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
@@ -13,14 +13,14 @@ class AddAttachment
 @Inject constructor(private val repository: JiraRepository) : UseCase<ResponseBody, AddAttachment.Params>() {
 
     companion object {
-        private val fileKey: String = "file"
+        private const val FILE_KEY: String = "file"
 
         fun prepareFilePart(file: File, mimetype: String): MultipartBody.Part {
-            return MultipartBody.Part.createFormData(fileKey, file.name, RequestBody.create(MediaType.parse(mimetype), file))
+            return MultipartBody.Part.createFormData(FILE_KEY, file.name, RequestBody.create(MediaType.parse(mimetype), file))
         }
 
         fun prepareFilePart(name: String, string: String, mimetype: String): MultipartBody.Part {
-            return MultipartBody.Part.createFormData(fileKey, name, RequestBody.create(MediaType.parse(mimetype), string))
+            return MultipartBody.Part.createFormData(FILE_KEY, name, RequestBody.create(MediaType.parse(mimetype), string))
         }
     }
 

--- a/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
@@ -2,14 +2,28 @@ package com.grio.lib.features.editor.cases
 
 import com.grio.lib.core.interactor.UseCase
 import com.grio.lib.features.editor.JiraRepository
+import okhttp3.MediaType
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import okhttp3.ResponseBody
+import java.io.File
 import javax.inject.Inject
 
 class AddAttachment
 @Inject constructor(private val repository: JiraRepository) : UseCase<ResponseBody, AddAttachment.Params>() {
 
+    val fileKey: String = "file"
+
     override suspend fun run(params: Params?) = repository.addAttachment(params!!.issueId, params.attachment)
 
-    data class Params(val issueId: String, val attachment: MultipartBody.Part)
+    data class Params(val issueId: String, val attachment: List<MultipartBody.Part>)
+
+    fun prepareFilePart(file: File, mimetype: String): MultipartBody.Part {
+        return MultipartBody.Part.createFormData(fileKey, file.name, RequestBody.create(MediaType.parse(mimetype), file))
+    }
+
+    fun prepareFilePart(name: String, string: String, mimetype: String): MultipartBody.Part {
+        return MultipartBody.Part.createFormData(fileKey, name, RequestBody.create(MediaType.parse(mimetype), string))
+    }
+
 }

--- a/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
+++ b/lib/src/main/java/com/grio/lib/features/editor/cases/AddAttachment.kt
@@ -12,18 +12,19 @@ import javax.inject.Inject
 class AddAttachment
 @Inject constructor(private val repository: JiraRepository) : UseCase<ResponseBody, AddAttachment.Params>() {
 
-    val fileKey: String = "file"
+    companion object {
+        private val fileKey: String = "file"
+
+        fun prepareFilePart(file: File, mimetype: String): MultipartBody.Part {
+            return MultipartBody.Part.createFormData(fileKey, file.name, RequestBody.create(MediaType.parse(mimetype), file))
+        }
+
+        fun prepareFilePart(name: String, string: String, mimetype: String): MultipartBody.Part {
+            return MultipartBody.Part.createFormData(fileKey, name, RequestBody.create(MediaType.parse(mimetype), string))
+        }
+    }
 
     override suspend fun run(params: Params?) = repository.addAttachment(params!!.issueId, params.attachment)
 
     data class Params(val issueId: String, val attachment: List<MultipartBody.Part>)
-
-    fun prepareFilePart(file: File, mimetype: String): MultipartBody.Part {
-        return MultipartBody.Part.createFormData(fileKey, file.name, RequestBody.create(MediaType.parse(mimetype), file))
-    }
-
-    fun prepareFilePart(name: String, string: String, mimetype: String): MultipartBody.Part {
-        return MultipartBody.Part.createFormData(fileKey, name, RequestBody.create(MediaType.parse(mimetype), string))
-    }
-
 }

--- a/lib/src/main/java/com/grio/lib/features/recorder/ReporterActivity.kt
+++ b/lib/src/main/java/com/grio/lib/features/recorder/ReporterActivity.kt
@@ -21,6 +21,7 @@ import com.grio.lib.features.editor.views.ScreenAnnotator
 import com.grio.lib.features.editor.views.Tool
 import com.grio.lib.features.editor.views.ToolOptions
 import kotlinx.android.synthetic.main.a_annotation.*
+import com.grio.lib.features.LogSnapshotManager
 import kotlinx.android.synthetic.main.a_reporter.*
 
 import java.io.File
@@ -80,7 +81,8 @@ class ReporterActivity :  BaseActivity() {
             if (summary.isNullOrBlank() || description.isNullOrBlank()) {
                 Toast.makeText(this, "Inputs must not be blank.", Toast.LENGTH_SHORT).show()
             } else {
-                viewModel.sendReportClicked(summary = summary, description = description, file = videoFile)
+                viewModel.log = LogSnapshotManager.getLogTail()
+                viewModel.sendReportClicked(summary = summary, description = description, file = videoFile, logString = viewModel.log)
             }
 
             return true

--- a/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
+++ b/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
@@ -13,13 +13,15 @@ class ReporterViewModel
 @Inject constructor(private val createIssue: CreateIssue, private val addAttachment: AddAttachment) : BaseViewModel() {
 
     var isLoading: MutableLiveData<Boolean> = MutableLiveData()
+    var log: String = ""
+
     private val files = ArrayList<MultipartBody.Part>()
 
     /**
      * Invoked when the "Add Ticket"
      * button is clicked.
      */
-    fun sendReportClicked(summary: String = "Default summary.", description: String = "Default Description.", file: File) {
+    fun sendReportClicked(summary: String = "Default summary.", description: String = "Default Description.", file: File, logString: String = "") {
         // Start loading
         isLoading.value = true
 
@@ -35,6 +37,10 @@ class ReporterViewModel
             // If successful, add attachment.
             if (file.isFile) {
                 files.add(AddAttachment.prepareFilePart(file, "video/*"))
+            }
+
+            if (logString.isNotEmpty()) {
+                files.add(AddAttachment.prepareFilePart("logcat.log", logString, "text/plain"))
             }
 
             addAttachment(AddAttachment.Params(it.id, files)) { it.either({

--- a/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
+++ b/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
@@ -5,9 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import com.grio.lib.core.platform.BaseViewModel
 import com.grio.lib.features.editor.cases.AddAttachment
 import com.grio.lib.features.editor.cases.CreateIssue
-import okhttp3.MediaType
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import java.io.File
 import javax.inject.Inject
 
@@ -36,7 +34,7 @@ class ReporterViewModel
 
             // If successful, add attachment.
             if (file.isFile) {
-                files.add(addAttachment.prepareFilePart(file, "video/*"))
+                files.add(AddAttachment.prepareFilePart(file, "video/*"))
             }
 
             addAttachment(AddAttachment.Params(it.id, files)) { it.either({

--- a/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
+++ b/lib/src/main/java/com/grio/lib/features/recorder/ReporterViewModel.kt
@@ -15,7 +15,7 @@ class ReporterViewModel
 @Inject constructor(private val createIssue: CreateIssue, private val addAttachment: AddAttachment) : BaseViewModel() {
 
     var isLoading: MutableLiveData<Boolean> = MutableLiveData()
-
+    private val files = ArrayList<MultipartBody.Part>()
 
     /**
      * Invoked when the "Add Ticket"
@@ -35,9 +35,11 @@ class ReporterViewModel
             Log.i("BugSnap", "Successfully create issue.")
 
             // If successful, add attachment.
-            val filePart = MultipartBody.Part.createFormData("file", file.name, RequestBody.create(MediaType.parse("video/*"), file))
+            if (file.isFile) {
+                files.add(addAttachment.prepareFilePart(file, "video/*"))
+            }
 
-            addAttachment(AddAttachment.Params(it.id, filePart)) { it.either({
+            addAttachment(AddAttachment.Params(it.id, files)) { it.either({
                 isLoading.value = false
                 Log.e("BugSnap", "Failed to upload attachment: $it")
             }, {

--- a/lib/src/test/java/com/grio/lib/features/editor/EditorViewModelTest.kt
+++ b/lib/src/test/java/com/grio/lib/features/editor/EditorViewModelTest.kt
@@ -39,7 +39,7 @@ class EditorViewModelTest : UnitTest() {
         val responseBody = mock(ResponseBody::class)
 
         given { runBlocking { createIssue.run(CreateIssue.Params("test", "test")) } }.willReturn(Either.Right(CreateIssueResponse("123", "BSP-22", "example.com/123")))
-        given { runBlocking { addAttachment.run(AddAttachment.Params("123", mock(MultipartBody.Part::class))) } }.willReturn(Either.Right(responseBody))
+        given { runBlocking { addAttachment.run(AddAttachment.Params("123", listOf(mock(MultipartBody.Part::class)))) } }.willReturn(Either.Right(responseBody))
 
         editorViewModel.isLoading.observeForever {
             with(it) {

--- a/lib/src/test/java/com/grio/lib/features/editor/JiraRepositoryTest.kt
+++ b/lib/src/test/java/com/grio/lib/features/editor/JiraRepositoryTest.kt
@@ -66,7 +66,7 @@ class JiraRepositoryTest : UnitTest() {
     fun `login service should return network failure when no connection`() {
         given { networkHandler.isConnected }.willReturn(false)
 
-        val res = networkRepository.addAttachment("123", mock(MultipartBody.Part::class))
+        val res = networkRepository.addAttachment("123", listOf(mock(MultipartBody.Part::class)))
 
         res shouldBeInstanceOf Either::class.java
         res.isLeft shouldEqual true
@@ -78,7 +78,7 @@ class JiraRepositoryTest : UnitTest() {
     fun `login service should return network failure when undefined connection`() {
         given { networkHandler.isConnected }.willReturn(null)
 
-        val res = networkRepository.addAttachment("123", mock(MultipartBody.Part::class))
+        val res = networkRepository.addAttachment("123", listOf(mock(MultipartBody.Part::class)))
 
         res shouldBeInstanceOf Either::class.java
         res.isLeft shouldEqual true


### PR DESCRIPTION
1.  addAttachment now requires a list of MultipartBody.Part.
- In order to reduce complexity, it is even required to wrap a single MultipartBody.Part item in a list.
- Fixed tests to support this new requirement
2. Added static method helpers in order to create the multipart items.
3. Added log to and multiple file upload to screen recorder option.